### PR TITLE
remove invisible wizard hats

### DIFF
--- a/svg/ying_comfy_sleep.svg
+++ b/svg/ying_comfy_sleep.svg
@@ -174,23 +174,6 @@
            d="m 1150.289,1075.2222 c 0,120.7167 -151.8603,218.5769 -272.57702,218.5769 -120.71671,0 -164.57695,-71.8602 -164.57699,-192.5769 -2e-5,-120.71675 97.86024,-244.57702 218.57699,-244.57701 120.71672,-2e-5 218.57702,97.86025 218.57702,218.57701 z"
            sodipodi:nodetypes="sssss" />
       </g>
-      <g
-         id="g10350"
-         transform="rotate(16.523108,-1682.5554,4529.9736)"
-         inkscape:label="wizard hat"
-         style="display:none">
-        <ellipse
-           style="fill:#5a2ca0;stroke:#442178;stroke-width:128;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
-           id="path10133"
-           cx="-156.11845"
-           cy="137.38425"
-           rx="1183.3779"
-           ry="243.54478" />
-        <path
-           style="fill:#5a2ca0;stroke:#442178;stroke-width:128;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:fill markers stroke;stop-color:#000000"
-           d="m -574.04058,136.8866 194.29066,-688.84869 604.95045,-547.54641 22.07849,1223.14801"
-           id="path10248" />
-      </g>
       <path
          style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#ffcb4c;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke;stop-color:#000000"
          d="M 422.09799,125.10137 C 599.10012,348.40199 720.6887,588.66091 734.81454,861.80682"

--- a/svg/ying_laptop_sleep.svg
+++ b/svg/ying_laptop_sleep.svg
@@ -194,23 +194,6 @@
            d="m 1150.289,1075.2222 c 0,120.7167 -151.8603,218.5769 -272.57702,218.5769 -120.71671,0 -164.57695,-71.8602 -164.57699,-192.5769 -2e-5,-120.71675 97.86024,-244.57702 218.57699,-244.57701 120.71672,-2e-5 218.57702,97.86025 218.57702,218.57701 z"
            sodipodi:nodetypes="sssss" />
       </g>
-      <g
-         id="g10350"
-         transform="rotate(16.523108,-1682.5554,4529.9736)"
-         inkscape:label="wizard hat"
-         style="display:none">
-        <ellipse
-           style="fill:#5a2ca0;stroke:#442178;stroke-width:128;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
-           id="path10133"
-           cx="-156.11845"
-           cy="137.38425"
-           rx="1183.3779"
-           ry="243.54478" />
-        <path
-           style="fill:#5a2ca0;stroke:#442178;stroke-width:128;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:fill markers stroke;stop-color:#000000"
-           d="m -574.04058,136.8866 194.29066,-688.84869 604.95045,-547.54641 22.07849,1223.14801"
-           id="path10248" />
-      </g>
       <path
          style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#ffcb4c;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke;stop-color:#000000"
          d="M 422.09799,125.10137 C 599.10012,348.40199 720.6887,588.66091 734.81454,861.80682"

--- a/svg/ying_sigh.svg
+++ b/svg/ying_sigh.svg
@@ -184,23 +184,6 @@
            transform="rotate(10.529837,874.0471,371.22829)"
            sodipodi:nodetypes="ssccs" />
       </g>
-      <g
-         id="g10350"
-         transform="rotate(16.523108,-1682.5554,4529.9736)"
-         inkscape:label="wizard hat"
-         style="display:none">
-        <ellipse
-           style="fill:#5a2ca0;stroke:#442178;stroke-width:128;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
-           id="path10133"
-           cx="-156.11845"
-           cy="137.38425"
-           rx="1183.3779"
-           ry="243.54478" />
-        <path
-           style="fill:#5a2ca0;stroke:#442178;stroke-width:128;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:fill markers stroke;stop-color:#000000"
-           d="m -574.04058,136.8866 194.29066,-688.84869 604.95045,-547.54641 22.07849,1223.14801"
-           id="path10248" />
-      </g>
       <path
          style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#ffcb4c;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke;stop-color:#000000"
          d="M 437.44693,127.9544 C 614.44906,351.25502 736.03764,591.51394 750.16348,864.65985"

--- a/svg/ying_sleep.svg
+++ b/svg/ying_sleep.svg
@@ -173,23 +173,6 @@
            d="m 1150.289,1075.2222 c 0,120.7167 -151.8603,218.5769 -272.57702,218.5769 -120.71671,0 -164.57695,-71.8602 -164.57699,-192.5769 -2e-5,-120.71675 97.86024,-244.57702 218.57699,-244.57701 120.71672,-2e-5 218.57702,97.86025 218.57702,218.57701 z"
            sodipodi:nodetypes="sssss" />
       </g>
-      <g
-         id="g10350"
-         transform="rotate(16.523108,-1682.5554,4529.9736)"
-         inkscape:label="wizard hat"
-         style="display:none">
-        <ellipse
-           style="fill:#5a2ca0;stroke:#442178;stroke-width:128;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
-           id="path10133"
-           cx="-156.11845"
-           cy="137.38425"
-           rx="1183.3779"
-           ry="243.54478" />
-        <path
-           style="fill:#5a2ca0;stroke:#442178;stroke-width:128;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:fill markers stroke;stop-color:#000000"
-           d="m -574.04058,136.8866 194.29066,-688.84869 604.95045,-547.54641 22.07849,1223.14801"
-           id="path10248" />
-      </g>
       <path
          style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#ffcb4c;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke;stop-color:#000000"
          d="M 422.09799,125.10137 C 599.10012,348.40199 720.6887,588.66091 734.81454,861.80682"

--- a/svg/ying_think_woozy.svg
+++ b/svg/ying_think_woozy.svg
@@ -232,23 +232,6 @@
            d="m 931.71289,856.64453 c -106.13201,-10e-6 -194.56749,95.74412 -214.39453,200.91407 139.35833,53.4666 286.55884,73.5965 432.19724,0 C 1140.5138,945.11083 1046.477,856.64451 931.71289,856.64453 Z"
            sodipodi:nodetypes="sccs" />
       </g>
-      <g
-         id="g10350"
-         transform="rotate(16.523108,-1682.5554,4529.9736)"
-         inkscape:label="wizard hat"
-         style="display:none">
-        <ellipse
-           style="fill:#5a2ca0;stroke:#442178;stroke-width:128;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
-           id="path10133"
-           cx="-156.11845"
-           cy="137.38425"
-           rx="1183.3779"
-           ry="243.54478" />
-        <path
-           style="fill:#5a2ca0;stroke:#442178;stroke-width:128;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:fill markers stroke;stop-color:#000000"
-           d="m -574.04058,136.8866 194.29066,-688.84869 604.95045,-547.54641 22.07849,1223.14801"
-           id="path10248" />
-      </g>
       <path
          style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#ffcb4c;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke;stop-color:#000000"
          d="M 422.09799,125.10137 C 599.10012,348.40199 720.6887,588.66091 734.81454,861.80682"

--- a/svg/ying_woozy.svg
+++ b/svg/ying_woozy.svg
@@ -180,23 +180,6 @@
            d="m 931.71289,856.64453 c -106.13201,-10e-6 -194.56749,95.74412 -214.39453,200.91407 139.35833,53.4666 286.55884,73.5965 432.19724,0 C 1140.5138,945.11083 1046.477,856.64451 931.71289,856.64453 Z"
            sodipodi:nodetypes="sccs" />
       </g>
-      <g
-         id="g10350"
-         transform="rotate(16.523108,-1682.5554,4529.9736)"
-         inkscape:label="wizard hat"
-         style="display:none">
-        <ellipse
-           style="fill:#5a2ca0;stroke:#442178;stroke-width:128;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
-           id="path10133"
-           cx="-156.11845"
-           cy="137.38425"
-           rx="1183.3779"
-           ry="243.54478" />
-        <path
-           style="fill:#5a2ca0;stroke:#442178;stroke-width:128;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;paint-order:fill markers stroke;stop-color:#000000"
-           d="m -574.04058,136.8866 194.29066,-688.84869 604.95045,-547.54641 22.07849,1223.14801"
-           id="path10248" />
-      </g>
       <path
          style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#ffcb4c;stroke-width:32;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke;stop-color:#000000"
          d="M 422.09799,125.10137 C 599.10012,348.40199 720.6887,588.66091 734.81454,861.80682"


### PR DESCRIPTION
removes hidden "wizard hat" group from a handful of .svg bases (even zhough zhey are so sovery pretty):

- ying_comfy_sleep.svg
- ying_laptop_sleep.svg
- ying_sigh.svg
- ying_sleep.svg
- ying_think_woozy.svg
- ying_woozy.svg

![image](https://github.com/user-attachments/assets/b0a7f946-effa-417f-a02f-41e29ce38994)
