### PR TITLE
Feature: Heterochromia

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The script `generate.py` is used to generate all the different colour palettes a
 
 running it as `python generate.py palette1 palette2 ...` will only export specific palettes, and `python generate.py emote1.svg emote2.svg ...` will only export specific emotes, these can be mixed and matched to export specific emotes in specific palettes eg `python generate.py yinglime ying_sit.svg`
 
-To add custom palettes, add the colors you want to `config.toml`, following the other `palette.name` tables as an example.  If you want hair and a tailpoof, set `show_all` to `true` in your palette. To hide any layer (ie if you want hair and no tailpoof), you can set its color to `#0000` to hide it completely.
+To add custom palettes, add the colors you want to `config.toml`, following the other `palette.name` tables as an example.  If you want hair and a tailpoof, set `show_all` to `true` in your palette. To hide any layer (ie if you want hair and no tailpoof), you can set its color to `#0000` to hide it completely. You may also customize the color of each eye individually by setting `heterochromia` to `true` in your palette. When enabled, `eye_left` and `eye_right` control eye color instead of `eye`.
 
 Changing the array `res` allows you to set any number of custom export resolutions you may need. The defaults are 128x128px and 720x720px.
 Setting the variable `reverse` to `true` will generate flipped versions of each emote as well, stored in a seperate /reversed/ folder for each palette.

--- a/generate.py
+++ b/generate.py
@@ -90,10 +90,10 @@ def trim_xmlns(tag):
 # ElementTree resolves xmlns of 'inkscape:label' like this i guess. angy angy
 inkscapeLabel = "{http://www.inkscape.org/namespaces/inkscape}label"
 
-# Find if the element is nested within a <g> with 'inkscape:label={name}'
-def in_group_labelled(name, elem):
+# Return true if the element, or one of its ancestors, has attribute 'inkscape:label="{name}"'
+def has_label(name, elem):
     while elem is not None:
-        if (trim_xmlns(elem.tag)=="g") and (elem.attrib.get(inkscapeLabel)==name):
+        if (elem.attrib.get(inkscapeLabel)==name):
             return True
         elem = elem.getparent()
     return False
@@ -215,7 +215,7 @@ for pal in palettes.keys():
                 rplKey = "wehh"
                 # heterochromia mode gogo
                 if (strokeKey=="eye") and ("heterochromia" in newcols) and (newcols["heterochromia"]):
-                    if in_group_labelled("left eye", elem): # find if we are on left eye
+                    if has_label("left eye", elem): # find if we are on left eye
                         rplKey = "eye_left"
                     else:
                         rplKey = "eye_right"
@@ -253,7 +253,7 @@ for pal in palettes.keys():
                     rplKey = "wehh"
                     # heterochromia mode gogo
                     if (fillKey=="eye") and ("heterochromia" in newcols) and (newcols["heterochromia"]):
-                        if in_group_labelled("left eye", elem): # find if we are on left eye
+                        if has_label("left eye", elem): # find if we are on left eye
                             rplKey = "eye_left"
                         else:
                             rplKey = "eye_right"

--- a/generate.py
+++ b/generate.py
@@ -229,13 +229,16 @@ for pal in palettes.keys():
 
                     if opacityOverride is not None:
                         # we can just set 'opacity' instead of 'fill-opacity' or 'stroke-opacity' separately
-                        if ";opacity:1" in style:
-                            style = style.replace(";opacity:1", ";opacity:" + str(opacityOverride))
+                        if "opacity:1" in style:
+                            # do not replace fill-opacity or stroke-opacity (they multiply); replace with a placeholder
+                            style = style.replace("-opacity", "~PLACEHOLDER~")
+                            style = style.replace("opacity:1", "opacity:" + str(opacityOverride))
+                            style = style.replace("~PLACEHOLDER~", "-opacity")
                         else:
                             style = "opacity:" + str(opacityOverride) + ";" + style #prepend
                 elif opacityOverride is not None:
-                    if ";stroke-opacity:1" in style:
-                        style = style.replace(";stroke-opacity:1", ";stroke-opacity:" + str(opacityOverride))
+                    if "stroke-opacity:1" in style:
+                        style = style.replace("stroke-opacity:1", "stroke-opacity:" + str(opacityOverride))
                     else:
                         style = "stroke-opacity:" + str(opacityOverride) + ";" + style #prepend
 
@@ -259,8 +262,8 @@ for pal in palettes.keys():
 
                     opacityOverride = newOpacity.get(rplKey) # override opacity if necessary
                     if opacityOverride is not None:
-                        if ";fill-opacity:1" in style:
-                            style = style.replace(";fill-opacity:1", ";fill-opacity:" + str(opacityOverride))
+                        if "fill-opacity:1" in style:
+                            style = style.replace("fill-opacity:1", "fill-opacity:" + str(opacityOverride))
                         else:
                             style = "fill-opacity:" + str(opacityOverride) + ";" + style #prepend
 

--- a/generate.py
+++ b/generate.py
@@ -5,6 +5,7 @@ from apng import APNG
 from PIL import Image
 from zipfile import ZipFile
 import webp
+from lxml import etree as ET
 
 #first load all svgs
 print("-- Finding SVGs...")
@@ -26,34 +27,35 @@ anim_data = json.load(f)
 
 
 defaultcols = {
-    "main":  "#ffcb4c",   #primary colour
-    "eye" :  "#fefefe",   #eye colour
-    "line" : "#65471b",   #line colours
-    "dark" : "#f19020",   #darker version of the primary colour for background details
-    "lid" :  "#d19020",   #eyelid colour
-    "hand" : "#a18020",   #hand colour, needs to be different from others for contrast
-    "tongue":"#ff5678",   #tongue colour (for all important bleps)
-    "hair" : "#123456",   #hair colour, only shown when show_all = True
-    "tail" : "#234567",   #tail colour, only shown when show_all = True
-    "heart_inner":"#ff5555",
-    "heart_outer":"#b10020",
-
-    "p2_main":  "#5fd3bc",   #p2 primary colour
-    "p2_eye" :  "#ccfefe",   #p2 eye colour
-    "p2_line" : "#165044",   #p2 line colours
-    "p2_dark" : "#389482",   #p2 darker version of the primary colour for background details
-    "p2_lid" :  "#2ca089",   #p2 eyelid colour
-    "p2_hand" : "#3a685f",   #p2 hand colour, needs to be different from others for contrast
-    "p2_tongue":"#8B305C",   #p2 tongue colour (for all important bleps)
-    "p2_hair" : "#345612",   #p2 hair colour, only shown when show_all = True
-    "p2_tail" : "#456723",   #p2 tail colour, only shown when show_all = True
-    "p2_heart_inner":"#00c3ff",
-    "p2_heart_outer":"#0080a2",
-
-    "show_all":False,      #show_all shows all hidden layers, this renders both the hair and tail tuft
-
-    # to hide either hair or tail seperately, set its color to #0000, this makes it transparent (must be exactly #0000 to work)
+    "main":        "#ffcb4c", #primary colour
+    "eye":         "#fefefe", #eye colour
+    "line":        "#65471b", #line colours
+    "dark":        "#f19020", #darker version of the primary colour for background details
+    "lid":         "#d19020", #eyelid colour
+    "hand":        "#a18020", #hand colour, needs to be different from others for contrast
+    "tongue":      "#ff5678", #tongue colour (for all important bleps)
+    "hair":        "#123456", #hair colour, only shown when show_all = True
+    "tail":        "#234567", #tail colour, only shown when show_all = True
+    "heart_inner": "#ff5555", #fill colour on hearts
+    "heart_outer": "#b10020", #line colour on hearts
     
+    "p2_main":        "#5fd3bc", #p2 primary colour
+    "p2_eye":         "#ccfefe", #p2 eye colour
+    "p2_line":        "#165044", #p2 line colours
+    "p2_dark":        "#389482", #p2 darker version of the primary colour for background details
+    "p2_lid":         "#2ca089", #p2 eyelid colour
+    "p2_hand":        "#3a685f", #p2 hand colour, needs to be different from others for contrast
+    "p2_tongue":      "#8B305C", #p2 tongue colour (for all important bleps)
+    "p2_hair":        "#345612", #p2 hair colour, only shown when show_all = True
+    "p2_tail":        "#456723", #p2 tail colour, only shown when show_all = True
+    "p2_heart_inner": "#00c3ff", #p2 fill colour on hearts
+    "p2_heart_outer": "#0080a2", #p2 line colour on hearts
+    
+    "show_all": False, #show_all shows all hidden layers, this renders both the hair and tail tuft
+    
+    "heterochromia": False #enable if you want each eye to have a different colour
+    
+    # to hide either hair or tail seperately, set its color to #0000, this makes it transparent (must be exactly #0000 to work)
 }
 
 config = toml.load("config.toml") #load config file
@@ -71,13 +73,27 @@ for pal in palettes.keys():
         palette_count += 1
 if(len(filtered_palettes.keys())>0):
     palettes = filtered_palettes
-    
 
 def convert_with_inkscape(file,res,out):
     #call inkscape from command line to export - this renders svgs slowly but accurately
     inkscape_path = "inkscape" #if youre getting errors saying command called inkscape isnt found, change this to the file path of your inkscape executable!
     args = inkscape_path + " " + file + " --export-area-page -w "+ str(res)+" -h "+ str(res)+" --export-filename=" + out
     print(subprocess.run(args,shell=True)) #if this says "returncode=0" thats good! if its not a zero thats bad, smths going wrong
+
+# find tags without namespace prepended by ElementTree
+def trim_xmlns(tag):
+    return tag.split('}', 1)[-1] if '}' in tag else tag
+
+# ElementTree resolves xmlns of 'inkscape:label' like this i guess. angy angy
+inkscapeLabel = "{http://www.inkscape.org/namespaces/inkscape}label"
+
+# Find if the element is nested within a <g> with 'inkscape:label={name}'
+def in_group_labelled(name, elem):
+    while elem is not None:
+        if (trim_xmlns(elem.tag)=="g") and (elem.attrib.get(inkscapeLabel)==name):
+            return True
+        elem = elem.getparent()
+    return False
 
 print("- Making output directory...")
 try:
@@ -87,38 +103,64 @@ except:
 
 for pal in palettes.keys():
     newcols = palettes[pal]
+    
+    # cache opacity override for each palette key if specified (#rgba or #rrggbbaa)
+    newOpacity = {}
+    for key in newcols.keys():
+        colorValue = newcols[key]
+        if not isinstance(colorValue, str): continue # skip non strings
+        
+        opacityOverride = 1
+        
+        if(len(colorValue)==5): # #rgba
+            opacityOverride = int(colorValue[4],16)/15
+            newcols[key] = colorValue[0:4] # trim alpha
+        elif(len(newcols[key])==9): # #rrggbbaa
+            opacityOverride = int(colorValue[7:9],16)/255
+            newcols[key] = colorValue[0:7] # trim alpha
+        
+        # override if needed
+        if(opacityOverride < 1):
+            newOpacity[key] = opacityOverride
+    
     #make all the folders!!
     print("- Making required directories for "+pal+"...")
+    
     for i in ["out/"+pal,"out/"+pal+"/svg","out/"+pal+"/svg/temp"]:
         try:
             os.mkdir(i)
         except:
             pass
+    
     for i in res:
         try:
             os.mkdir("out/"+pal+"/png"+str(i))
         except:
             pass
+        
         try:
             os.mkdir("out/"+pal+"/temp"+str(i))
         except:
             pass
+        
         if(doWebp):
             try:
                 os.mkdir("out/"+pal+"/webp"+str(i))
             except:
                 pass
-
+    
     if reverse: #make reversed directories too if we need them
         try:
             os.mkdir("out/"+pal+"/reversed/")
         except:
             pass
+        
         for i in res:
             try:
                 os.mkdir("out/"+pal+"/reversed/png"+str(i))
             except:
                 pass
+            
             try:
                 os.mkdir("out/"+pal+"/reversed/temp"+str(i))
             except:
@@ -128,51 +170,105 @@ for pal in palettes.keys():
         if(len(sys.argv)>1+palette_count):
             if(vectorfile not in sys.argv):
                 continue #if files are specified as arguments, only export those files
+        
         data = ""
         print("- Changing "+vectorfile+" to "+pal+"...")
+        
         #hell yeah lets ctrl+h the heck out of this file
         with open("svg/"+vectorfile, 'r') as f:
             data = f.read()
-            for key in newcols.keys():
-                if(key!="show_all"):
-                    if(len(newcols[key])==5 or len(newcols[key])==9): #check if in a #rgba or #rrggbbaa format
-                        new_opacity = 1
-                        if(len(newcols[key])==5):
-                            new_opacity = int(newcols[key][4],16)/15
+            
+            # context-aware parsing
+            root = ElementTree.fromstring(data)
+            
+            for elem in root.iter():
+                # only looking for paths
+                if (trim_xmlns(elem.tag)!="path"): continue
+                
+                # get style of path, or skip if it doesn't have style
+                style_key = next((k for k in elem.attrib if local_name(k) == "style"), None)
+                if style_key is None: continue
+                style = elem.attrib
+                
+                # Locate fill/stroke that have color literals matching a key in defaultcols; if so, mark for replacement
+                strokeKey = None
+                strokeStyleText = None
+                fillKey = None
+                fillStyleText = None
+                fillRpl = None
+                
+                for key, color in defaultcols.items():
+                    sT = f"stroke:{color};"
+                    fT = f"fill:{color};"
+                    
+                    if sT in style:
+                        strokeStyleText = sT
+                        strokeKey = key
+                    if fT in style:
+                        fillStyleText = fT
+                        fillKey = key
+                
+            #<-- for elem in root.iter():
+                if strokeKey is not None:
+                    rplKey = "wehh"
+                    # heterochromia mode gogo
+                    if (strokeKey=="eye") and ("heterochromia" in newcols) and (newcols["heterochromia"]):
+                        if in_group_labelled("left eye", elem): # find if we are on left eye
+                            rplKey = "eye_left"
                         else:
-                            new_opacity = int(newcols[key][7:9],16)/255
-                        datalined = data.split("\n")
-                        for line in range(len(datalined)): #loop through lines of text
-                            if ("fill:"+defaultcols[key] in datalined[line]) and ("stroke:"+defaultcols[key] in datalined[line]): #both fill and stroke?
-                                if ";opacity:1;" in datalined[line]: #look for previously set opacity
-                                    datalined[line] = datalined[line].replace(";opacity:1",";opacity:"+str(new_opacity))
-                                else:
-                                    datalined[line] = datalined[line].replace('style="', 'style="opacity:'+str(new_opacity)+';')
-                            elif "fill:"+defaultcols[key] in datalined[line]: #if fill, only change fill opacity
-                                if "fill-opacity:1;" in datalined[line]: #look for previously set opacity
-                                    datalined[line] = datalined[line].replace("fill-opacity:1","fill-opacity:"+str(new_opacity))
-                                else:
-                                    datalined[line] = datalined[line].replace('style="', 'style="fill-opacity:'+str(new_opacity)+';')
-                            elif "stroke:"+defaultcols[key] in datalined[line]: #if stroke, only change stroke opacity
-                                if "stroke-opacity:1;" in datalined[line]: #look for previously set opacity
-                                    datalined[line] = datalined[line].replace("stroke-opacity:1","stroke-opacity:"+str(new_opacity))
-                                else:
-                                    datalined[line] = datalined[line].replace('style="', 'style="stroke-opacity:'+str(new_opacity)+';')
+                            rplKey = "eye_right"
+                    else: # regular palette swap
+                        rplKey = strokeKey
+                    
+                    opacityOverride = newOpacity.get(rplKey) # override opacity if necessary
+                    
+                    if(strokeKey==fillKey): # we can replace both at once if so
+                        fillRpl = "fill:" + newcols[rplKey] + ";" # set fill's replacement here to save cycles (speedrunning)
                         
-                        data = "\n".join(datalined) # recombine lines
-                    data = data.replace(defaultcols[key],"PLACEHOLDER_"+key)
-            for key in newcols.keys():
-                if(key!="show_all"):
-                    new_color = newcols[key]
-                    if(len(new_color)==5):
-                        new_color = new_color[0:4] #trim transparency digit
-                    if(len(new_color)==9):
-                        new_color = new_color[0:7] #trim transparency digits
-                    data = data.replace("PLACEHOLDER_"+key,new_color)
-            if("show_all" in newcols.keys()):
-                if(newcols["show_all"]):
-                    data = data.replace("display:none;","display:inline;")
-    
+                        if opacityOverride is not None:
+                            # we can just set 'opacity' instead of 'fill-opacity' or 'stroke-opacity' separately
+                            if ";opacity:1" in style:
+                                style = style.replace(";opacity:1", ";opacity:" + str(opacityOverride))
+                            else:
+                                style = "opacity:" + str(opacityOverride) + ";" + style #prepend
+                    elif opacityOverride is not None:
+                        if ";stroke-opacity:1" in style:
+                            style = style.replace(";stroke-opacity:1", ";stroke-opacity:" + str(opacityOverride))
+                        else:
+                            style = "stroke-opacity:" + str(opacityOverride) + ";" + style #prepend
+                    
+                    style = style.replace(strokeStyleText, "stroke:" + newcols[rplKey] + ";")
+                
+            #<-- for elem in root.iter():
+                if fillKey is not None:
+                    if fillRpl is not None:
+                        style = style.replace(fillStyleText, fillRpl)
+                        continue
+                    
+                    rplKey = "wehh"
+                    # heterochromia mode gogo
+                    if (fillKey=="eye") and ("heterochromia" in newcols) and (newcols["heterochromia"]):
+                        if in_group_labelled("left eye", elem): # find if we are on left eye
+                            rplKey = "eye_left"
+                        else:
+                            rplKey = "eye_right"
+                    else: # regular palette swap
+                        rplKey = fillKey
+                    
+                    opacityOverride = newOpacity.get(rplKey) # override opacity if necessary
+                    if opacityOverride is not None:
+                        if ";fill-opacity:1" in style:
+                            style = style.replace(";fill-opacity:1", ";fill-opacity:" + str(opacityOverride))
+                        else:
+                            style = "fill-opacity:" + str(opacityOverride) + ";" + style #prepend
+                    
+                    style = style.replace(fillStyleText, "fill:" + newcols[rplKey] + ";")
+                
+                # unhide fur if enabled
+                if ("show_all" in newcols) and newcols["show_all"]:
+                    style = style.replace("display:none", "display:inline")
+            #<-- for elem in root.iter():
+        
         #check if files are already exported and if so, skip them
         allpngs = False
         allreversed = False
@@ -193,17 +289,17 @@ for pal in palettes.keys():
         print(" - Saving vector "+pal+"/svg/"+vectorfile.replace("ying",pal)+"...")
         with open("out/"+pal+"/svg/"+vectorfile.replace("ying",pal), 'w') as f:
             f.write(data)
-
+        
         for i in res:
             if not allpngs:
                 if(vectorfile in temps):
                     print(" - Saving image "+pal+"/temp"+str(i)+"/"+vectorfile.replace(".svg",".png").replace("ying",pal).replace("temp/","")+"...")
                     convert_with_inkscape("out/"+pal+"/svg/"+vectorfile.replace("ying",pal), i, "out/"+pal+"/temp"+str(i)+"/"+vectorfile.replace(".svg",".png").replace("ying",pal).replace("temp/",""))
-                    
+                
                 else:
                     print(" - Saving image "+pal+"/png"+str(i)+"/"+vectorfile.replace(".svg",".png").replace("ying",pal)+"...")
                     convert_with_inkscape("out/"+pal+"/svg/"+vectorfile.replace("ying",pal), i, "out/"+pal+"/png"+str(i)+"/"+vectorfile.replace(".svg",".png").replace("ying",pal))
-
+            
             if reverse and not allreversed:
                 if(vectorfile in temps):
                     print("  - Reversing "+"/temp"+str(i)+"/"+vectorfile.replace(".svg",".png").replace("ying",pal).replace("temp/","")+"...")
@@ -213,7 +309,6 @@ for pal in palettes.keys():
                     print("  - Reversing "+pal+"/png"+str(i)+"/"+vectorfile.replace(".svg",".png").replace("ying",pal)+"...")
                     img = Image.open("out/"+pal+"/png"+str(i)+"/"+vectorfile.replace(".svg",".png").replace("ying",pal))
                     img.transpose(Image.Transpose.FLIP_LEFT_RIGHT).save("out/"+pal+"/reversed/png"+str(i)+"/"+vectorfile.replace(".svg",".png").replace("ying","rev"+pal))
-
     
     for i in res:
         for anim_name in anim_data["anims"].keys(): 
@@ -231,7 +326,7 @@ for pal in palettes.keys():
                     else:
                         im.append_file("out/"+pal+"/png"+str(i)+"/"+frame[0].replace("ying",pal),delay=frame[1])
                 im.save("out/"+pal+"/png"+str(i)+"/"+anim_name.replace("ying",pal))
-
+            
             if reverse: #do it again for reversed images if needed!
                 for frame in anim:
                     if not os.path.exists("out/"+pal+"/reversed/png"+str(i)+"/"+frame[0].replace("ying","rev"+pal)) and not os.path.exists("out/"+pal+"/reversed/temp"+str(i)+"/"+frame[0].replace("ying","rev"+pal).replace("temp/","")):
@@ -245,8 +340,7 @@ for pal in palettes.keys():
                         else:
                             im.append_file("out/"+pal+"/reversed/png"+str(i)+"/"+frame[0].replace("ying","rev"+pal),delay=frame[1])
                     im.save("out/"+pal+"/reversed/png"+str(i)+"/"+anim_name.replace("ying","rev"+pal))
-                    
-
+            
             if doWebp:
                 enc = webp.WebPAnimEncoder.new(i, i)
                 timestamp_ms = 0
@@ -263,8 +357,7 @@ for pal in palettes.keys():
                 animd = enc.assemble(timestamp_ms)
                 with open("out/"+pal+"/webp"+str(i)+"/"+anim_name.replace("ying",pal).replace(".png",".webp"), 'wb') as f:
                     f.write(animd.buffer())
-
-
+    
     for i in ["export","export/tarballs"]:
         try:
             os.mkdir(i)

--- a/generate.py
+++ b/generate.py
@@ -229,13 +229,17 @@ for pal in palettes.keys():
 
                     if opacityOverride is not None:
                         # we can just set 'opacity' instead of 'fill-opacity' or 'stroke-opacity' separately
+
+                        # avoid 'fill-opacity' and 'stroke-opacity' by swapping for placeholder
+                        style = style.replace("-opacity", "~PLACEHOLDER~")
+
                         if "opacity:1" in style:
-                            # do not replace fill-opacity or stroke-opacity (they multiply); replace with a placeholder
-                            style = style.replace("-opacity", "~PLACEHOLDER~")
                             style = style.replace("opacity:1", "opacity:" + str(opacityOverride))
-                            style = style.replace("~PLACEHOLDER~", "-opacity")
                         else:
                             style = "opacity:" + str(opacityOverride) + ";" + style #prepend
+
+                        # restore placeholders
+                        style = style.replace("~PLACEHOLDER~", "-opacity")
                 elif opacityOverride is not None:
                     if "stroke-opacity:1" in style:
                         style = style.replace("stroke-opacity:1", "stroke-opacity:" + str(opacityOverride))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ apng
 pillow
 toml
 webp
+lxml

--- a/svg/ying_pixel.svg
+++ b/svg/ying_pixel.svg
@@ -68,7 +68,8 @@
         <path
            id="path42"
            style="opacity:1;fill:#fefefe;fill-opacity:1;stroke:none;stroke-width:48;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:192;paint-order:fill markers stroke"
-           d="M 853.33398,853.33398 V 960 H 746.66602 v 213.334 H 853.33398 V 1280 H 1066.666 v -106.666 h 106.668 V 960 H 1066.666 V 853.33398 Z" />
+           d="M 853.33398,853.33398 V 960 H 746.66602 v 213.334 H 853.33398 V 1280 H 1066.666 v -106.666 h 106.668 V 960 H 1066.666 V 853.33398 Z"
+           inkscape:label="left eye" />
         <rect
            style="opacity:1;fill:#65471b;fill-opacity:1;stroke:none;stroke-width:48;stroke-linecap:round;stroke-linejoin:round;stroke-dashoffset:192;paint-order:fill markers stroke"
            id="rect43"

--- a/svg/ying_stare.svg
+++ b/svg/ying_stare.svg
@@ -155,20 +155,20 @@
       </g>
       <g
          id="g15"
-         inkscape:label="right eye"
+         inkscape:label="left eye"
          style="display:inline;stroke-width:1.07692"
          transform="matrix(-0.92857508,0,0,0.92857508,1466.4498,-10.736953)">
         <path
            id="path14"
            style="opacity:1;fill:#fefefe;stroke:#65471b;stroke-width:68.9228;stroke-linecap:round;stroke-linejoin:round;paint-order:fill markers stroke;stop-color:#000000"
-           inkscape:label="righteye"
+           inkscape:label="lefteye"
            d="m 1059.5005,1102.1225 c 0,120.7167 -144.81714,176.5452 -203.3269,191.6766 -116.87171,30.2246 -145.35607,-86.9916 -145.35611,-207.7083 -2e-5,-120.71677 93.68598,-227.99157 210.48876,-197.5015 83.72875,21.85648 138.19425,92.81644 138.19425,213.5332 z"
            sodipodi:nodetypes="sssss" />
         <path
            style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#65471b;stroke-width:51.6921;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke;stop-color:#000000"
            d="M 840.57507,982.49252 V 1172.3674"
            id="path15"
-           inkscape:label="right pupil" />
+           inkscape:label="left pupil" />
       </g>
     </g>
     <path


### PR DESCRIPTION
Allows zhe user to configure each eye's color individually

![vivi](https://github.com/user-attachments/assets/bbfcfa2a-eb02-4bca-a725-adf6a097e086)
![vivi_3c](https://github.com/user-attachments/assets/eb964f52-c62d-4feb-903f-b9a54d674493)
![vivi_stare](https://github.com/user-attachments/assets/61e5aa4e-95ee-425b-b9c6-5200988bc7b6)

### Changes

- Add: new palette keys
  - `heterochromia` (`True` or `False`): When `True`, enables heterochromia mode
  - `eye_left` (`#rrggbb`): Controls color of 'left' eye in heterochromia mode
  - `eye_right` (`#rrggbb`): Controls color of 'right' eye in heterochromia mode
- Change: Context-aware parsing was required to search zhe XML tree to find `inkscape:label="left eye"` in element hierarchy
  - Replaced find-and-replace logic wizh ElementTree crawling logic
- Change: Some svgs wizhout a defined "left eye" were modified to have one
- Style: "fixed" (as in my IDE did it for me, sorry) indentations on empty lines & alignment in `defaultcols`
- Dist: `lxml` is added to requirements.txt

### Benefits

- pretty
- it works i zhink (i verified all 355 output emojis by hand for "looking correct"ness)

### Drawbacks

- written by a scatterbrained yinglet wizh no prior pyzhon experience
- spaghetti
- over-engineered
- additional dependency
- heavier zhan replace-based logic
- percentage of users who will utilize zhis feature is limited

![vivi_shrug_amused](https://github.com/user-attachments/assets/b739b279-c820-4a01-a47d-b9403f51068a)
